### PR TITLE
PPL Functional for T5 Model

### DIFF
--- a/CL_learner.py
+++ b/CL_learner.py
@@ -85,7 +85,16 @@ class Seq2SeqToD(pl.LightningModule):
         # To Implement
 
         logging.error(f"In Compute PPL with: batch ({batch}), task_id: ({task_id}), and tokenizer ({tokenizer})")
-        raise("THIS IS INVALID")
+        with torch.no_grad():
+            out_tuple = self.model(
+                input_ids=batch["input_id_PPL"].to(device),
+                attention_mask=None,
+                labels=None,
+                task_id=task_id
+            )
+            logging.warn(f'Out Tuple is: {out_tuple}')
+
+        raise "THIS BREAKS"
         if task_id == -1:
             return torch.tensor([1.0])
         else:

--- a/CL_learner.py
+++ b/CL_learner.py
@@ -83,14 +83,11 @@ class Seq2SeqToD(pl.LightningModule):
 
     def compute_PPL(self, batch, task_id=-1, device="cuda", tokenizer=None):
         # To Implement
-
-        logging.error(f"In Compute PPL with: batch ({batch}), task_id: ({task_id}), and tokenizer ({tokenizer})")
         with torch.no_grad():
             model_out = self.model(
                 input_ids=batch["input_id_PPL"].to(device),
                 labels=batch['output_id_PPL'].to(device)
             )
-            logging.warn(f'Model Out is: {model_out}')
 
         shift_logits = model_out.logits[..., :-1, :].contiguous()
         shift_labels = batch["output_id_PPL"].to(device)[..., 1:].contiguous()

--- a/CL_learner.py
+++ b/CL_learner.py
@@ -4,6 +4,7 @@ from torch.nn import CrossEntropyLoss
 from random import sample
 import pytorch_lightning as pl
 import logging
+logging.basicConfig()
 
 from transformers import (
     AdamW,
@@ -17,8 +18,6 @@ from transformers import (
 )
 from utils.dataloader import get_data_loaders, get_current_task_data, make_loader
 from collections import defaultdict
-
-logger = logging.getLogger(__name__)
 
 class Seq2SeqToD(pl.LightningModule):
     def __init__(self, args):
@@ -85,7 +84,7 @@ class Seq2SeqToD(pl.LightningModule):
     def compute_PPL(self, batch, task_id=-1, device="cuda", tokenizer=None):
         # To Implement
 
-        logger.error(f"In Compute PPL with: batch ({batch}), task_id: ({task_id}), and tokenizer ({tokenizer})")
+        logging.error(f"In Compute PPL with: batch ({batch}), task_id: ({task_id}), and tokenizer ({tokenizer})")
         raise("THIS IS INVALID")
         if task_id == -1:
             return torch.tensor([1.0])

--- a/CL_learner.py
+++ b/CL_learner.py
@@ -3,6 +3,8 @@ import torch
 from torch.nn import CrossEntropyLoss
 from random import sample
 import pytorch_lightning as pl
+import logging
+
 from transformers import (
     AdamW,
     GPT2Tokenizer,
@@ -16,6 +18,7 @@ from transformers import (
 from utils.dataloader import get_data_loaders, get_current_task_data, make_loader
 from collections import defaultdict
 
+logger = logging.getLogger(__name__)
 
 class Seq2SeqToD(pl.LightningModule):
     def __init__(self, args):
@@ -81,6 +84,9 @@ class Seq2SeqToD(pl.LightningModule):
 
     def compute_PPL(self, batch, task_id=-1, device="cuda", tokenizer=None):
         # To Implement
+
+        logger.error(f"In Compute PPL with: batch ({batch}), task_id: ({task_id}), and tokenizer ({tokenizer})")
+        raise("THIS IS INVALID")
         if task_id == -1:
             return torch.tensor([1.0])
         else:

--- a/CL_learner.py
+++ b/CL_learner.py
@@ -88,9 +88,7 @@ class Seq2SeqToD(pl.LightningModule):
         with torch.no_grad():
             model_out = self.model(
                 input_ids=batch["input_id_PPL"].to(device),
-                attention_mask=None,
-                labels=None,
-                return_dict = True
+                labels=batch['output_id_PPL'].to(device)
             )
             logging.warn(f'Model Out is: {model_out}')
 

--- a/test.py
+++ b/test.py
@@ -182,7 +182,9 @@ def generate_sample_prev_task(
     task_id_adpt=-1,
 ):
     # device = torch.device(f"cuda:{args.GPU[0]}")
-    device = torch.device(f"cuda:0")
+    device = "cpu"
+    if (torch.cuda.is_available()):
+        device = torch.device(f"cuda:0")
     model.to(device)
     model.eval()
     ## notice that this sample is just to have the data struct
@@ -248,7 +250,9 @@ def generate_sample_prev_task(
 
 
 def test_model_seq2seq(args, model, tokenizer, test_loader, time="0_['']"):
-    device = torch.device(f"cuda:0")
+    device = "cpu"
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:0")
     model.to(device)
     model.eval()
     results = []
@@ -302,7 +306,9 @@ def test_model_seq2seq_ADAPTER(
     args, model, tokenizer, test_loader, test_dataset, time="0_['']", max_seen_task=0
 ):
     # device = torch.device(f"cuda:{args.GPU[0]}")
-    device = torch.device(f"cuda:0")
+    device = "cpu"
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:0")
     model.model.to(device)
     model.model.eval()
     results = []

--- a/train.py
+++ b/train.py
@@ -213,7 +213,7 @@ def train(hparams, *args):
                 ],
             }
             if torch.cuda.is_available():
-                train_params['gpus'] = [0]
+                train_parameters['gpus'] = [0]
 
             trainer = Trainer(
                 **train_parameters

--- a/train.py
+++ b/train.py
@@ -51,7 +51,8 @@ def get_free_gpu(num_gpu):
 
 os.environ["CUDA_VISIBLE_DEVICES"] = get_free_gpu(1)
 reserve = torch.tensor(1)
-reserve.to("cuda:0")
+if torch.cuda.is_available():
+    reserve.to("cuda:0")
 
 
 def get_checkpoint(log_dir, index_to_load):
@@ -112,12 +113,12 @@ def train(hparams, *args):
 
     if hparams.multi:
         start = time.time()
-        trainer = Trainer(
-            default_root_dir=hparams.saving_dir,
-            accumulate_grad_batches=hparams.gradient_accumulation_steps,
-            gradient_clip_val=hparams.max_norm,
-            max_epochs=hparams.n_epochs,
-            callbacks=[
+        train_parameters = {
+            'default_root_dir': hparams.saving_dir,
+            'accumulate_grad_batches': hparams.gradient_accumulation_steps,
+            'gradient_clip_val': hparams.max_norm,
+            'max_epochs': hparams.n_epochs,
+            'callbacks': [
                 pl.callbacks.EarlyStopping(
                     monitor="val_loss",
                     min_delta=0.00,
@@ -126,8 +127,11 @@ def train(hparams, *args):
                     mode="min",
                 ),
             ],
-            gpus=[0],
-        )
+        }
+        if torch.cuda.is_available():
+            train_parameters['gpus'] = [0]
+
+        trainer = Trainer(**train_parameters)
         trainer.fit(model, train_loader, val_loader)
         end = time.time()
         print("Time elapsed:", end - start)
@@ -180,14 +184,14 @@ def train(hparams, *args):
             print()
             print(f"TASK:{task_id}")
             start = time.time()
-            trainer = Trainer(
-                default_root_dir=f"{hparams.saving_dir}/{task_num}_{task_id}",
-                accumulate_grad_batches=hparams.gradient_accumulation_steps,
-                gradient_clip_val=hparams.max_norm,
-                max_steps=hparams.n_steps,
-                max_epochs=1000,
-                check_val_every_n_epoch=1000,
-                callbacks=[
+            train_params = {
+                'default_root_dir': f"{hparams.saving_dir}/{task_num}_{task_id}",
+                'accumulate_grad_batches': hparams.gradient_accumulation_steps,
+                'gradient_clip_val': hparams.max_norm,
+                'max_steps': hparams.n_steps,
+                'max_epochs': 1000,
+                'check_val_every_n_epoch': 1000,
+                'callbacks': [
                     ValEveryNSteps(20),
                     pl.callbacks.ModelCheckpoint(
                         monitor="val_loss", save_on_train_epoch_end=False
@@ -201,8 +205,12 @@ def train(hparams, *args):
                         check_on_train_epoch_end=False,
                     ),
                 ],
-                gpus=[0],
-                # limit_train_batches=100,
+            }
+            if torch.cuda.is_available():
+                train_params['gpus'] = [0]
+
+            trainer = Trainer(
+                **train_params
             )
             trainer.fit(model, task_loader, val_loader[task_id])
             end = time.time()

--- a/train.py
+++ b/train.py
@@ -32,9 +32,11 @@ import subprocess
 import numpy as np
 
 import warnings
+import logging
 
 warnings.filterwarnings("ignore")
 
+logger = logging.getLogger(__name__)
 
 def get_free_gpu(num_gpu):
     cmd = "nvidia-smi -q -d pids |grep -A4 GPU|grep Processes >tmp"
@@ -111,6 +113,7 @@ def train(hparams, *args):
     if hparams.CL == "GEM":
         model.set_up_gem()
 
+
     if hparams.multi:
         start = time.time()
         train_parameters = {
@@ -130,6 +133,9 @@ def train(hparams, *args):
         }
         if torch.cuda.is_available():
             train_parameters['gpus'] = [0]
+
+
+
 
         trainer = Trainer(**train_parameters)
         trainer.fit(model, train_loader, val_loader)
@@ -184,7 +190,7 @@ def train(hparams, *args):
             print()
             print(f"TASK:{task_id}")
             start = time.time()
-            train_params = {
+            train_parameters = {
                 'default_root_dir': f"{hparams.saving_dir}/{task_num}_{task_id}",
                 'accumulate_grad_batches': hparams.gradient_accumulation_steps,
                 'gradient_clip_val': hparams.max_norm,
@@ -210,7 +216,7 @@ def train(hparams, *args):
                 train_params['gpus'] = [0]
 
             trainer = Trainer(
-                **train_params
+                **train_parameters
             )
             trainer.fit(model, task_loader, val_loader[task_id])
             end = time.time()

--- a/train.py
+++ b/train.py
@@ -33,10 +33,10 @@ import numpy as np
 
 import warnings
 import logging
+logging.basicConfig()
 
 warnings.filterwarnings("ignore")
 
-logger = logging.getLogger(__name__)
 
 def get_free_gpu(num_gpu):
     cmd = "nvidia-smi -q -d pids |grep -A4 GPU|grep Processes >tmp"

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -12,6 +12,8 @@ import pytorch_lightning as pl
 import random
 import math
 from tabulate import tabulate
+import logging
+logging.basicConfig()
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -43,7 +45,12 @@ class ValEveryNSteps(pl.Callback):
             trainer._run_evaluate()
             trainer.state.stage = stage
             trainer.training = True
-            trainer.logger_connector._epoch_end_reached = False
+
+            try:
+                trainer.logger_connector._epoch_end_reached = False
+            except AttributeError:
+                logging.error("Could not find logger_connecter")
+
             self.last_run = trainer.global_step
 
 


### PR DESCRIPTION
This branch is two fold:
+ Testing locally on my `M1 MacBook Pro` was failing due to hardcoded calls to `.cuda()` or `.to("cuda:0")`. These occurrences have been replaced with the guard:
```
device = "cpu"
if torch.cuda.is_available():
    device = "cuda:0"
```
+ Errors were happening with PPL due to the fact that the original PPL calculation was designed for decoder only models. I read documentation from [HuggingFace](https://huggingface.co/docs/transformers/model_doc/t5#:~:text=loss%20%3D%20model(input_ids%3Dinput_ids%2C%20attention_mask%3Dattention_mask%2C%20labels%3Dlabels).loss) which seems to suggest that by specifying less parameters in the call to run the model we can actually get [a richer representation back ](https://huggingface.co/docs/transformers/v4.18.0/en/main_classes/output#transformers.modeling_outputs.Seq2SeqLMOutput) which we can then query the `logits` from and pass it to the original code that was calculating perplexity. Hopefully this gives a way to easily transition to computing PPL without diverging too much from the initial representation 
   - [ ] TODO: Check that this function on the GPT2 model returns the same values as what was originally being calculated
   - [ ] TODO: Verify that training completes as expected for a full pass of `T5` training.